### PR TITLE
Update hadoop.version build argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ For internal toast usage if you are compiling locally
 use following command 
 
 # Apache Hadoop 2.7.X and later
-./build/mvn -Pyarn -Phadoop-2.7 -Dhadoop.version=VERSION -DskipTests clean package
+./build/mvn -Pyarn -Phadoop-2.7 -Dhadoop.version=3.1.0 -DskipTests clean package
 
 
 # Apache Spark


### PR DESCRIPTION
to have a legit value (currently 3.1.0)

## What changes were proposed in this pull request?

The build command needs to have real hadoop version I believe. So this puts that value.

## How was this patch tested?

Kicked off the build on my local

Please review http://spark.apache.org/contributing.html before opening a pull request.
