### PR TITLE
 Updating to hadoop 3.1.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,6 @@ import spark
 spark {
   notify = false
   hadoop_profile = '3.1'
-  hadoop_version = '3.1.0'
+  hadoop_version = '3.1.3'
   toast_build_ops = '-Ptoast-lib-enhancement'
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 use following command
 
 Apache Hadoop 3.1.X and later
-./build/mvn -Ptoast-lib-enhancement -Pyarn -Phadoop-3.1 -Dhadoop.version=3.1.0 -DskipTests clean package
+./build/mvn -Ptoast-lib-enhancement -Pyarn -Phadoop-3.1 -Dhadoop.version=3.1.3 -DskipTests clean package
 
 # Apache Spark
 

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -74,7 +74,6 @@
       <artifactId>spark-repl_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
-
     <!--
       Because we don't shade dependencies anymore, we need to restore Guava to compile scope so
       that the libraries Spark depend on have it available. We'll package the version that Spark
@@ -307,6 +306,13 @@
               <artifactId>*</artifactId>
             </exclusion>
           </exclusions>
+        </dependency>
+        <dependency>
+          <!-- Need guava 27.0-jre for compatibility with hadoop-3.1.3 -->
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <scope>compile</scope>
+          <version>27.0-jre</version>
         </dependency>
       </dependencies>
     </profile>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -74,6 +74,7 @@
       <artifactId>spark-repl_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
+
     <!--
       Because we don't shade dependencies anymore, we need to restore Guava to compile scope so
       that the libraries Spark depend on have it available. We'll package the version that Spark


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updating spark build to use hadoop-3.1.3 up from hadoop-3.1.0 in order to get fix for https://issues.apache.org/jira/browse/HADOOP-16109. 

I observed this bug in pre-prod and have seen it before, although it's rare. For awhile I had thought we had truncated dataframe parquet files. But since finding this bug report it seems to match our error pretty closely.

I had to make it so guava 27.0-jre makes it to the assembly jars; otherwise we get runtime error from hadoop-3.1.3. They apparently upgraded guava in the hadoop stack since 3.1.0.

Update: this has now been seen in production: https://sentry.io/organizations/toast/issues/1405471263/?project=189022

## How was this patch tested?

Re-built spark and deployed to a standalone host with Zeppelin running in local mode. Read and queried the same dataframe and query that fails on our current spark build with hadoop-3.1.0. 

Original stack trace of error (if you want to copy/paste it):
```
java.io.EOFException: Reached the end of stream with 1227 bytes left to read
	at org.apache.parquet.io.DelegatingSeekableInputStream.readFully(DelegatingSeekableInputStream.java:104)
	at org.apache.parquet.io.DelegatingSeekableInputStream.readFullyHeapBuffer(DelegatingSeekableInputStream.java:127)
	at org.apache.parquet.io.DelegatingSeekableInputStream.readFully(DelegatingSeekableInputStream.java:91)
	at org.apache.parquet.hadoop.ParquetFileReader$ConsecutiveChunkList.readAll(ParquetFileReader.java:1174)
	at org.apache.parquet.hadoop.ParquetFileReader.readNextRowGroup(ParquetFileReader.java:805)
	at org.apache.spark.sql.execution.datasources.parquet.VectorizedParquetRecordReader.checkEndOfRowGroup(VectorizedParquetRecordReader.java:301)
	at org.apache.spark.sql.execution.datasources.parquet.VectorizedParquetRecordReader.nextBatch(VectorizedParquetRecordReader.java:256)
	at org.apache.spark.sql.execution.datasources.parquet.VectorizedParquetRecordReader.nextKeyValue(VectorizedParquetRecordReader.java:159)
	at org.apache.spark.sql.execution.datasources.RecordReaderIterator.hasNext(RecordReaderIterator.scala:39)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.hasNext(FileScanRDD.scala:101)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.nextIterator(FileScanRDD.scala:181)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.hasNext(FileScanRDD.scala:101)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.scan_nextBatch_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.agg_doAggregateWithKeys_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$13$$anon$1.hasNext(WholeStageCodegenExec.scala:636)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
	at org.apache.spark.shuffle.sort.UnsafeShuffleWriter.write(UnsafeShuffleWriter.java:187)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:55)
	at org.apache.spark.scheduler.Task.run(Task.scala:123)
	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:408)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
Pictures below:

![image](https://user-images.githubusercontent.com/43964293/71737232-1a675700-2e21-11ea-8489-5110790e4347.png)

![image](https://user-images.githubusercontent.com/43964293/71737378-7a5dfd80-2e21-11ea-9490-047b3e6a811f.png)

---
### Update April 2021:

I did further tests of this upgrade by building an analytics container and worker AMI and deploying these to preprod. Instructions for how I did this are [here](https://toasttab.atlassian.net/wiki/spaces/DP/pages/2085323660/Testing+spark+rebuilds+in+preprod). The G2 application in cluster and local mode have been fine as has the converter workflows.