### PR TITLE
simple config option to speed up catalog loading

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -400,7 +400,8 @@ class InMemoryCatalog(
 
       try {
         val fs = tablePath.getFileSystem(hadoopConfig)
-        if (!fs.exists(partitionPath)) {
+        val checkExists = conf.getBoolean("toast.spark.catalog.checkExistsEnabled", true)
+        if (checkExists && !fs.exists(partitionPath)) {
           fs.mkdirs(partitionPath)
         }
       } catch {


### PR DESCRIPTION
This exists call slows down the initial population of the spark catalog. This is especially an issue since we have many tables with 3K+ partitions and doing an exists on ever partition path before populating the spark catalog is needlessly slow. This change should be simple to port to spark 3.0 when needed and in the absolute worst case we will have a performance regression.

This option should be completely safe to use on access profiles that simply run queries and dont do writes.

It may also be safe to enable on profiles that do writes as well, but that should be tested more.