### PR TITLE
Add spark-alchemy to toast-lib-enhancement Maven profile

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -315,6 +315,11 @@
           <scope>compile</scope>
           <version>27.0-jre</version>
         </dependency>
+        <dependency>
+          <groupId>com.swoop</groupId>
+          <artifactId>spark-alchemy_${scala.binary.version}</artifactId>
+          <version>${spark-alchemy.version}</version>
+        </dependency>
       </dependencies>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@
 
     <!-- Toast Lib Enhancement -->
     <spark-cassandra-connector.version>2.4.1</spark-cassandra-connector.version>
+    <spark-alchemy.version>0.5.5</spark-alchemy.version>
     <!--
     Managed up from older version from Avro; sync with jackson-module-paranamer dependency version
     -->


### PR DESCRIPTION
Adds spark-alchemy JAR to the assembly module (set of dependency jars that make it to our spork distribution) under the `toast-lib-enhancement` maven profile, which we set up to easily distinguish the jars we added to the out-of-the-box spark build.

Jars added with this change:
```
$ diff assembly-jar-list-before.txt assembly-jar-list-after.txt 
47a48
> fastutil-6.5.11.jar
72a74,75
> hll-1.6.0.jar
> hll-1.6.0-sources.jar
180a184
> spark-alchemy_2.11-0.5.5.jar
```

This builds with the same command from the README: `/build/mvn -Ptoast-lib-enhancement -Pyarn -Phadoop-3.1 -Dhadoop.version=3.1.3 -DskipTests clean package`