### PR TITLE
Remove aws-java-sdk-core exclusion

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -157,12 +157,12 @@
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-java-sdk-core</artifactId>
           <version>${aws.java.sdk.version}</version>
-          <exclusions>
+          <!--exclusions>
             <exclusion>
               <groupId>*</groupId>
               <artifactId>*</artifactId>
             </exclusion>
-          </exclusions>
+          </exclusions-->
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Comment out exclusion policy for aws-java-sdk-core

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Manually tested. No longer receive the `java.lang.NoClassDefFoundError: org/apache/http/params/HttpParams` error when reading from s3 using a spark build with this exclusion removed. 

Please review http://spark.apache.org/contributing.html before opening a pull request.
