### PR TITLE
[DP-2308] Avro decoding compatibility 3.2 

### DIFF
--- a/external/avro/src/main/scala/org/apache/spark/sql/avro/shim/AvroDataToCatalystCompat.scala
+++ b/external/avro/src/main/scala/org/apache/spark/sql/avro/shim/AvroDataToCatalystCompat.scala
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.avro.shim
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericDatumReader
+import org.apache.avro.io.{BinaryDecoder, DecoderFactory}
+import org.apache.spark.SparkException
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.avro._
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, SpecificInternalRow, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeGenerator, CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.util.{FailFastMode, ParseMode, PermissiveMode}
+import org.apache.spark.sql.types._
+
+import scala.util.control.NonFatal
+
+/**
+ * This trait does the actual decoding logic for a given schema and should be created by a given AvroDecoderFactory
+ */
+trait AvroDecoder {
+    def decode(input: Array[Byte]): Any
+}
+
+/**
+ * Implementing this trait allows the implementer to define how to decode avro records for a particular schema.
+ */
+trait AvroDecoderFactory {
+    def create(schema: Schema): AvroDecoder
+}
+
+class DirectBinaryAvroDecoder(avroSchema: Schema) extends AvroDecoder {
+    @transient lazy val reader = new GenericDatumReader[Any](avroSchema)
+    
+    @transient private var decoder: BinaryDecoder = _
+    
+    @transient private var result: Any = _
+    
+    override def decode(binary: Array[Byte]): Any = {
+        decoder = DecoderFactory.get().binaryDecoder(binary, 0, binary.length, decoder)
+        result = reader.read(result, decoder)
+    }
+    
+}
+
+
+class DirectBinaryAvroDecoderFactory extends AvroDecoderFactory {
+    override def create(schema: Schema) : AvroDecoder = {
+        return new DirectBinaryAvroDecoder(schema)
+    }
+}
+
+
+/**
+* This is a modified version of AvroDataToCatalyst from version 3.2 which replaces the built in avro decoding functionality.
+*/
+case class AvroDataToCatalystCompat(
+    child: Expression,
+    jsonFormatSchema: String,
+    options: Map[String, String],
+    decoderFactory: AvroDecoderFactory = new DirectBinaryAvroDecoderFactory())
+  extends UnaryExpression with ExpectsInputTypes {
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(BinaryType)
+
+  override lazy val dataType: DataType = {
+    val dt = SchemaConverters.toSqlType(expectedSchema).dataType
+    parseMode match {
+      // With PermissiveMode, the output Catalyst row might contain columns of null values for
+      // corrupt records, even if some of the columns are not nullable in the user-provided schema.
+      // Therefore we force the schema to be all nullable here.
+      case PermissiveMode => dt.asNullable
+      case _ => dt
+    }
+  }
+
+  override def nullable: Boolean = true
+
+  private lazy val avroOptions = AvroOptions(options)
+
+  @transient private lazy val actualSchema = new Schema.Parser().parse(jsonFormatSchema)
+
+  @transient private lazy val expectedSchema = avroOptions.schema.getOrElse(actualSchema)
+
+  @transient private lazy val avroDecoder = decoderFactory.create(actualSchema)
+
+  //@transient private lazy val reader = new GenericDatumReader[Any](avroSchema)  //Replaced with decoderFactory
+
+  @transient private lazy val deserializer =
+    new AvroDeserializer(expectedSchema, dataType, avroOptions.datetimeRebaseModeInRead)
+
+  //@transient private var decoder: BinaryDecoder = _ //Replaced with decoderFactory
+
+  //@transient private var result: Any = _  //Replaced with decoderFactory
+
+  @transient private lazy val parseMode: ParseMode = {
+    val mode = avroOptions.parseMode
+    if (mode != PermissiveMode && mode != FailFastMode) {
+      throw new AnalysisException(unacceptableModeMessage(mode.name))
+    }
+    mode
+  }
+
+  private def unacceptableModeMessage(name: String): String = {
+    s"from_avro() doesn't support the $name mode. " +
+      s"Acceptable modes are ${PermissiveMode.name} and ${FailFastMode.name}."
+  }
+
+  @transient private lazy val nullResultRow: Any = dataType match {
+      case st: StructType =>
+        val resultRow = new SpecificInternalRow(st.map(_.dataType))
+        for(i <- 0 until st.length) {
+          resultRow.setNullAt(i)
+        }
+        resultRow
+
+      case _ =>
+        null
+    }
+
+
+  override def nullSafeEval(input: Any): Any = {
+    val binary = input.asInstanceOf[Array[Byte]]
+    try {
+
+      val result = avroDecoder.decode(binary)
+      val deserialized = deserializer.deserialize(result)
+      assert(deserialized.isDefined,
+        "Avro deserializer cannot return an empty result because filters are not pushed down")
+      deserialized.get
+    } catch {
+      // There could be multiple possible exceptions here, e.g. java.io.IOException,
+      // AvroRuntimeException, ArrayIndexOutOfBoundsException, etc.
+      // To make it simple, catch all the exceptions here.
+      case NonFatal(e) => parseMode match {
+        case PermissiveMode => nullResultRow
+        case FailFastMode =>
+          throw new SparkException("Malformed records are detected in record parsing. " +
+            s"Current parse Mode: ${FailFastMode.name}. To process malformed records as null " +
+            "result, try setting the option 'mode' as 'PERMISSIVE'.", e)
+        case _ =>
+          throw new AnalysisException(unacceptableModeMessage(parseMode.name))
+      }
+    }
+  }
+
+  override def prettyName: String = "from_avro"
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val expr = ctx.addReferenceObj("this", this)
+    nullSafeCodeGen(ctx, ev, eval => {
+      val result = ctx.freshName("result")
+      val dt = CodeGenerator.boxedType(dataType)
+      s"""
+        $dt $result = ($dt) $expr.nullSafeEval($eval);
+        if ($result == null) {
+          ${ev.isNull} = true;
+        } else {
+          ${ev.value} = $result;
+        }
+      """
+    })
+  }
+
+  override protected def withNewChildInternal(newChild: Expression): AvroDataToCatalystCompat =
+    copy(child = newChild)
+}


### PR DESCRIPTION
which can exist in both spark 2.4 and spark 3.2

so analytics can compile against both 2.4 and 3.2 and still use the optmial
avro decoding performance.

It uses traits/java interfaces to define how tto decode avro records so the
schema resolver classes don't need to be known when building spark but can be provided
by a udf jar.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
