### PR TITLE
DP-2449: New constructor for CatalystSqlParser

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, SQLConfHelper, TableId
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.errors.QueryParsingErrors
 import org.apache.spark.sql.types.{DataType, StructType}
 
@@ -138,10 +139,9 @@ abstract class AbstractSqlParser extends ParserInterface with SQLConfHelper with
  */
 class CatalystSqlParser extends AbstractSqlParser {
   val astBuilder = new AstBuilder
-}
-
-class CatalystSqlParser(val conf: SQLConf) extends AbstractSqlParser {
-  val astBuilders = new AstBuilder
+  def this(conf: SQLConf) {
+    this()
+  }
 }
 
 /** For test-only. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -140,6 +140,10 @@ class CatalystSqlParser extends AbstractSqlParser {
   val astBuilder = new AstBuilder
 }
 
+class CatalystSqlParser(val conf: SQLConf) extends AbstractSqlParser {
+  val astBuilders = new AstBuilder
+}
+
 /** For test-only. */
 object CatalystSqlParser extends CatalystSqlParser
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
New constructor for `CatalystSqlParser` that will allow us to compile toast-analytics with spark 3.2. Adds auxiliary constructor that takes in a SQLConf, but simply calls the primary constructor. Just to make it possible to compile analytics code.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
