### PR TITLE
[DP-2494] Upgrade aws s3 libs to more up to date version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <avro.version>1.10.2</avro.version>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
-    <aws.java.sdk.version>1.11.655</aws.java.sdk.version>
+    <aws.java.sdk.version>1.11.901</aws.java.sdk.version>
     <!-- the producer is used in tests -->
     <aws.kinesis.producer.version>0.12.8</aws.kinesis.producer.version>
     <!--  org.apache.httpcomponents/httpclient-->


### PR DESCRIPTION
This was tested locally with zeppelin and is waiting on a clean build of our analytics service.

Tested:
- [x] zeppelin local only
- [x] service iTest build
- [ ] zeppelin local cluster with master and workers.
- [ ] Converter (likely Needs analytics project changes for spark 3)


This may break spark integration of kinesis but we don't use that and s3 is far more important